### PR TITLE
fix corewaap docu URLs as of recent multi-version change

### DIFF
--- a/usp-core-waap-error-mapping/intro/info.md
+++ b/usp-core-waap-error-mapping/intro/info.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-3.0-only
 
 **USP Core WAAP** serves as a crucial building block in a defense in depth strategy and mitigates the risk of exposing severe vulnerabilities. It acts as a reverse proxy in a Kubernetes cluster in front of the target web application. USP Core WAAP is a web application firewall with a broad security feature set utilizing positive and negative security policies such as [OWASP CRS](https://owasp.org/www-project-modsecurity-core-rule-set/) rules, request/response header filtering, cross site request forgery ([CSRF](https://owasp.org/www-community/attacks/csrf)) protection and [OpenAPI schema validation](https://openapis.org).
 
-This scenario shows the usage of [custom error pages](https://docs.united-security-providers.ch/usp-core-waap/error-mapping/) to improve error handling and prevent information leakage.
+This scenario shows the usage of [custom error pages](https://docs.united-security-providers.ch/usp-core-waap/latest/error-mapping/) to improve error handling and prevent information leakage.
 
 > &#128270; In this scenario the [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) demo web application is used as a backend.
 

--- a/usp-core-waap-error-mapping/step1/info.md
+++ b/usp-core-waap-error-mapping/step1/info.md
@@ -23,4 +23,4 @@ As you can see, a lot of background information (source code filenames and compo
 
 The behavior of the profile page is a bug in the backend application. The application should redirect you to the login page if you are not logged in yet. USP Core WAAP can protect you from exposing such an improper error handling to the user.
 
-Now let's see how you can use [custom error pages](https://docs.united-security-providers.ch/usp-core-waap/error-mapping/) **provided by USP Core WAAP** in the next step!
+Now let's see how you can use [custom error pages](https://docs.united-security-providers.ch/usp-core-waap/latest/error-mapping/) **provided by USP Core WAAP** in the next step!

--- a/usp-core-waap-fp-autolearn/intro/info.md
+++ b/usp-core-waap-fp-autolearn/intro/info.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-only
 
 > &#8987; Make sure to checkout the [manual configuration tuning scenario](../usp-core-waap-fp-intro) first prior to this one!
 
-This scenario shows how to tackle **false positives** as a next step to the [manual configuration tuning scenario](../usp-core-waap-fp-intro) using the [auto-learning feature](https://docs.united-security-providers.ch/usp-core-waap/autolearning/).
+This scenario shows how to tackle **false positives** as a next step to the [manual configuration tuning scenario](../usp-core-waap-fp-intro) using the [auto-learning feature](https://docs.united-security-providers.ch/usp-core-waap/latest/autolearning/).
 
 > &#128270; In this scenario the [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) demo web application is used as a backend.
 

--- a/usp-core-waap-fp-autolearn/step2/info.md
+++ b/usp-core-waap-fp-autolearn/step2/info.md
@@ -46,7 +46,7 @@ Go ahead and download the java cli tool using
 ```shell
 version=$(helm list -n usp-core-waap-operator -o json | jq -r '.[] | select(.name == "usp-core-waap-operator") | .app_version')
 curl -so /tmp/waap-lib-autolearn-cli-${version}.jar \
- https://docs.united-security-providers.ch/usp-core-waap/files/waap-lib-autolearn-cli-${version}.jar || echo "failed to download version ${version}, exiting..."
+ https://docs.united-security-providers.ch/usp-core-waap/latest/files/waap-lib-autolearn-cli-${version}.jar || echo "failed to download version ${version}, exiting..."
 ```{{exec}}
 
 Next execute it showing the help page using

--- a/usp-core-waap-header-filtering/intro/info.md
+++ b/usp-core-waap-header-filtering/intro/info.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-3.0-only
 
 **USP Core WAAP** serves as a crucial building block in a defense in depth strategy and mitigates the risk of exposing severe vulnerabilities. It acts as a reverse proxy in a Kubernetes cluster in front of the target web application. USP Core WAAP is a web application firewall with a broad security feature set utilizing positive and negative security policies such as [OWASP CRS](https://owasp.org/www-project-modsecurity-core-rule-set/) rules, request/response header filtering, cross-site request forgery ([CSRF](https://owasp.org/www-community/attacks/csrf)) protection, and [OpenAPI schema validation](https://openapis.org).
 
-This scenario shows how **header filtering** can mitigate an application vulnerability prior to applying the application fix itself. To get more background about header filtering, read the [Core WAAP documentation](https://docs.united-security-providers.ch/usp-core-waap/).
+This scenario shows how **header filtering** can mitigate an application vulnerability prior to applying the application fix itself. To get more background about header filtering, read the [Core WAAP documentation](https://docs.united-security-providers.ch/usp-core-waap/latest/).
 
 > &#128270; In this scenario a [demo next.js application](https://github.com/lirantal/vulnerable-nextjs-14-CVE-2025-29927) is used as a backend.
 

--- a/usp-core-waap-header-filtering/step1/info.md
+++ b/usp-core-waap-header-filtering/step1/info.md
@@ -146,4 +146,4 @@ curl -v \
 
 Without an authorization header, this request got access to the "sensitive" area, completely bypassing the Next.js middleware authorization code!
 
-Now let's see how [header filtering](https://docs.united-security-providers.ch/usp-core-waap/crd-doc/#corewaapservicespecheaderfiltering) **provided by USP Core WAAP** safeguards you in the next step!
+Now let's see how [header filtering](https://docs.united-security-providers.ch/usp-core-waap/latest/crd-doc/#corewaapservicespecheaderfiltering) **provided by USP Core WAAP** safeguards you in the next step!

--- a/usp-core-waap-header-filtering/step2/info.md
+++ b/usp-core-waap-header-filtering/step2/info.md
@@ -54,7 +54,7 @@ corewaapservice.waap.core.u-s-p.ch/nextjs-app-core-waap created
 
 > &#10071; In order to show the header filtering feature here the Coraza Web Application firewall feature has been set to detect only (that feature too will block the crafted header "x-middleware-subrequest: middleware:middleware:middleware:middleware:middleware" by default to be recognizable in that case by the `HTTP 403` response)
 
-This resource uses the default security configuration of header filtering where preconfigured by the `STANDARD` list of headers (see [documentation](https://docs.united-security-providers.ch/usp-core-waap/crd-doc/#corewaapservicespecheaderfilteringrequest)) unknown headers are removed.
+This resource uses the default security configuration of header filtering where preconfigured by the `STANDARD` list of headers (see [documentation](https://docs.united-security-providers.ch/usp-core-waap/latest/crd-doc/#corewaapservicespecheaderfilteringrequest)) unknown headers are removed.
 
 <details>
 <summary>hint</summary>

--- a/usp-core-waap-header-filtering/step3/info.md
+++ b/usp-core-waap-header-filtering/step3/info.md
@@ -12,7 +12,7 @@ As seen by this demo here, the default configuration of USP Core WAAP header fil
 
 ### Header filtering configuration
 
-> &#128270; Refer to the [header filtering documentation](https://docs.united-security-providers.ch/usp-core-waap/crd-doc/#corewaapservicespecheaderfilteringrequest) for a complete list of available configuration options.
+> &#128270; Refer to the [header filtering documentation](https://docs.united-security-providers.ch/usp-core-waap/latest/crd-doc/#corewaapservicespecheaderfilteringrequest) for a complete list of available configuration options.
 
 By inspecting the list of headers against a list of predefined headers and custom allowed / denied headers, the feature will remove headers accordingly.
 
@@ -36,7 +36,7 @@ In this case you can maintain a list of custom allowed request headers using `sp
 
 > &#128270; If you had configured the previously seen `x-middleware-subrequest` which enables bypassing Next.js middleware authorization code in specific versions, you should consider removing it (please refer to the [blog post from JFrog](https://jfrog.com/blog/cve-2025-29927-next-js-authorization-bypass/)).
 
-Similarly to customize the allowed request headers, you can also configure a list of [deny patterns](https://docs.united-security-providers.ch/usp-core-waap/crd-doc/#corewaapservicespecheaderfilteringrequestdenyindex) to **always deny request headers** matching that pattern (also when configured in `allow` or present in the configured `allowClass`).
+Similarly to customize the allowed request headers, you can also configure a list of [deny patterns](https://docs.united-security-providers.ch/usp-core-waap/latest/crd-doc/#corewaapservicespecheaderfilteringrequestdenyindex) to **always deny request headers** matching that pattern (also when configured in `allow` or present in the configured `allowClass`).
 
 To completely disable request header filtering, set `spec.headerFiltering.request.enabled` to `false` in which case no request header inspection will be executed (this is different from `logOnly` where inspection is executed but no modifications are made!).
 
@@ -44,6 +44,6 @@ To completely disable request header filtering, set `spec.headerFiltering.reques
 
 Response header filtering will use a predefined `STANDARD` list, being the only one available, being the reason why there is no `spec.headerFiltering.response.allowClass` available.
 
-In response header filtering, you can configure custom allowed response headers using `spec.headerFiltering.response.allow` attribute and a list of [deny headers](https://docs.united-security-providers.ch/usp-core-waap/crd-doc/#corewaapservicespecheaderfilteringresponse) to **always deny** matching that name (also when configured in `allow` or the default internal used `STANDARD` list).
+In response header filtering, you can configure custom allowed response headers using `spec.headerFiltering.response.allow` attribute and a list of [deny headers](https://docs.united-security-providers.ch/usp-core-waap/latest/crd-doc/#corewaapservicespecheaderfilteringresponse) to **always deny** matching that name (also when configured in `allow` or the default internal used `STANDARD` list).
 
 To completely disable request header filtering, set `spec.headerFiltering.response.enabled` to `false`, in which case no request header inspection will be executed (this is different from `logOnly` where inspection is executed but no modifications are made!).

--- a/usp-core-waap-intro/step3/info.md
+++ b/usp-core-waap-intro/step3/info.md
@@ -44,7 +44,7 @@ spec:
           selection: h1
 ```{{copy}}
 
-> &#128270; This definition raises the default [Paranoia Level](https://coreruleset.org/docs/2-how-crs-works/2-2-paranoia_levels/) from 1 to 2 in order to mitigate an SQLite specific injection (`' or 1==1;--`) as well and by doing that solving an appearing `false positive` using a [requestRuleException](https://docs.united-security-providers.ch/usp-core-waap/crd-doc/#corewaapservicespeccrsrequestruleexceptionsindex) to still allow basket checkouts)
+> &#128270; This definition raises the default [Paranoia Level](https://coreruleset.org/docs/2-how-crs-works/2-2-paranoia_levels/) from 1 to 2 in order to mitigate an SQLite specific injection (`' or 1==1;--`) as well and by doing that solving an appearing `false positive` using a [requestRuleException](https://docs.united-security-providers.ch/usp-core-waap/latest/crd-doc/#corewaapservicespeccrsrequestruleexceptionsindex) to still allow basket checkouts)
 
 You can now re-check if a USP Core WAAP instance is active in the `juiceshop` namespace:
 

--- a/usp-core-waap-openapi-intro/intro/info.md
+++ b/usp-core-waap-openapi-intro/intro/info.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-3.0-only
 
 **USP Core WAAP** serves as a crucial building block in a defense in depth strategy and mitigates the risk of exposing severe vulnerabilities. It acts as a reverse proxy in a Kubernetes cluster in front of the target web application. USP Core WAAP is a web application firewall with a broad security feature set utilizing positive and negative security policies such as [OWASP CRS](https://owasp.org/www-project-modsecurity-core-rule-set/) rules, request/response header filtering, cross site request forgery ([CSRF](https://owasp.org/www-community/attacks/csrf)) protection and [OpenAPI schema validation](https://openapis.org).
 
-This scenario shows how to protect an API endpoint having an OpenAPI specification for using the [USP Core WAAP OpenAPI validation](https://docs.united-security-providers.ch/usp-core-waap/openapi-validation/) feature.
+This scenario shows how to protect an API endpoint having an OpenAPI specification for using the [USP Core WAAP OpenAPI validation](https://docs.united-security-providers.ch/usp-core-waap/latest/openapi-validation/) feature.
 
 [OpenAPI specification](https://swagger.io/docs/specification/v3_0/about/) is an API description for REST APIs and allows to describe (or more specifically define) your application API. To learn more about the OpenAPI specification head over to the [documentation](https://swagger.io/docs/specification/v3_0/basic-structure/).
 

--- a/usp-core-waap-virtual-patch/step1/info.md
+++ b/usp-core-waap-virtual-patch/step1/info.md
@@ -18,4 +18,4 @@ The [prometheus application]({{TRAFFIC_HOST1_9090}}) has been setup and will be 
 
 Access the [pprof debug page]({{TRAFFIC_HOST1_9090}}/debug/pprof) which is an issue as this endpoint can be used to trigger a [DoS](https://en.wikipedia.org/wiki/Denial-of-service_attack) event.
 
-Now let's see how you can use [virtual patching](https://docs.united-security-providers.ch/usp-core-waap/crs-virtual-patch/) **provided by USP Core WAAP** in the next step!
+Now let's see how you can use [virtual patching](https://docs.united-security-providers.ch/usp-core-waap/latest/crs-virtual-patch/) **provided by USP Core WAAP** in the next step!

--- a/usp-core-waap-virtual-patch/step2/info.md
+++ b/usp-core-waap-virtual-patch/step2/info.md
@@ -31,7 +31,7 @@ SecRule REQUEST_URI "^/debug/pprof" \
  msg:'Access to /debug/pprof denied'"
 ```
 
-As explained in the [Core WAAP documentation](https://docs.united-security-providers.ch/usp-core-waap/crs-virtual-patch/) rules should be configured using [folded style](https://yaml.org/spec/1.2.2/#813-folded-style) strings with [stripping chomping indicator](https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator) (i.e. >-) and no extra indentation or trailing slashes and **must use an ID between 300000 and 399999**, like:
+As explained in the [Core WAAP documentation](https://docs.united-security-providers.ch/usp-core-waap/latest/crs-virtual-patch/) rules should be configured using [folded style](https://yaml.org/spec/1.2.2/#813-folded-style) strings with [stripping chomping indicator](https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator) (i.e. >-) and no extra indentation or trailing slashes and **must use an ID between 300000 and 399999**, like:
 
 ```yaml
 ...


### PR DESCRIPTION
this will re-enable the documentation URLs after we recently updated the documentation github-pages to be multi version.